### PR TITLE
Rounds: Fixed that `WaitingRound` never triggered after a round started

### DIFF
--- a/code/gamemode/Game.Util.cs
+++ b/code/gamemode/Game.Util.cs
@@ -67,5 +67,10 @@ namespace TTTReborn.Gamemode
 
             return players;
         }
+
+        public static bool HasMinimumPlayers()
+        {
+            return Client.All.Count >= TTTReborn.Gamemode.Game.TTTMinPlayers;
+        }
     }
 }

--- a/code/gamemode/Game.cs
+++ b/code/gamemode/Game.cs
@@ -28,7 +28,29 @@ namespace TTTReborn.Gamemode
             }
         }
 
+        /// <summary>
+        /// Changes the round if minimum players is met. Otherwise, force changes to "WaitingRound"
+        /// </summary>
+        /// <param name="round"> The round to change to if minimum players is met.</param>
         public void ChangeRound(BaseRound round)
+        {
+            Assert.NotNull(round);
+
+            if (Game.HasMinimumPlayers())
+            {
+                ForceRoundChange(round);
+            }
+            else
+            {
+                ForceRoundChange(new WaitingRound());
+            }
+        }
+
+        /// <summary>
+        /// Force changes a round regardless of player count.
+        /// </summary>
+        /// <param name="round"> The round to change to.</param>
+        public void ForceRoundChange(BaseRound round)
         {
             Assert.NotNull(round);
 
@@ -116,7 +138,7 @@ namespace TTTReborn.Gamemode
 
         private async void StartGameTimer()
         {
-            ChangeRound(new WaitingRound());
+            ForceRoundChange(new WaitingRound());
 
             while (true)
             {

--- a/code/gamemode/Game.cs
+++ b/code/gamemode/Game.cs
@@ -52,8 +52,6 @@ namespace TTTReborn.Gamemode
         /// <param name="round"> The round to change to.</param>
         public void ForceRoundChange(BaseRound round)
         {
-            Assert.NotNull(round);
-
             Round.Finish();
             Round = round;
             Round.Start();

--- a/code/rounds/InProgressRound.cs
+++ b/code/rounds/InProgressRound.cs
@@ -173,5 +173,25 @@ namespace TTTReborn.Rounds
                 winningTeam.Color
             );
         }
+
+        private bool CheckMinimumPlayers()
+        {
+            return Client.All.Count >= TTTReborn.Gamemode.Game.TTTMinPlayers;
+        }
+
+        public override void OnSecond()
+        {
+            if (Host.IsServer)
+            {
+                if (CheckMinimumPlayers())
+                {
+                    base.OnSecond();
+                }
+                else if (IsRoundOver() == null)
+                {
+                    Gamemode.Game.Instance.ChangeRound(new WaitingRound());
+                }
+            }
+        }
     }
 }

--- a/code/rounds/InProgressRound.cs
+++ b/code/rounds/InProgressRound.cs
@@ -11,6 +11,8 @@ using TTTReborn.Teams;
 
 namespace TTTReborn.Rounds
 {
+    using Gamemode;
+
     public class InProgressRound : BaseRound
     {
         public override string RoundName => "In Progress";
@@ -167,7 +169,7 @@ namespace TTTReborn.Rounds
 
         private static void LoadPostRound(TTTTeam winningTeam)
         {
-            Gamemode.Game.Instance.ChangeRound(new PostRound());
+            Gamemode.Game.Instance.ForceRoundChange(new PostRound());
             TTTPlayer.ClientOpenAndSetPostRoundMenu(
                 winningTeam.Name,
                 winningTeam.Color
@@ -183,13 +185,14 @@ namespace TTTReborn.Rounds
         {
             if (Host.IsServer)
             {
-                if (CheckMinimumPlayers())
+                base.OnSecond();
+
+                if (!Game.HasMinimumPlayers())
                 {
-                    base.OnSecond();
-                }
-                else if (IsRoundOver() == null)
-                {
-                    Gamemode.Game.Instance.ChangeRound(new WaitingRound());
+                    if (IsRoundOver() == null)
+                    {
+                        Gamemode.Game.Instance.ForceRoundChange(new WaitingRound());
+                    }
                 }
             }
         }

--- a/code/rounds/PostRound.cs
+++ b/code/rounds/PostRound.cs
@@ -17,7 +17,11 @@ namespace TTTReborn.Rounds
         {
             // TODO: Allow users to close the menu themselves using mouse cursor.
             TTTPlayer.ClientClosePostRoundMenu();
-            Gamemode.Game.Instance.ChangeRound(new PreRound());
+
+            if (CheckMinimumPlayers())
+            {
+                Gamemode.Game.Instance.ChangeRound(new PreRound());
+            }
 
             base.OnTimeUp();
         }
@@ -59,6 +63,18 @@ namespace TTTReborn.Rounds
                     }
                 }
             }
+        }
+
+        private bool CheckMinimumPlayers()
+        {
+            if (Client.All.Count < TTTReborn.Gamemode.Game.TTTMinPlayers)
+            {
+                TTTReborn.Gamemode.Game.Instance.ChangeRound(new WaitingRound());
+
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/code/rounds/PostRound.cs
+++ b/code/rounds/PostRound.cs
@@ -15,15 +15,12 @@ namespace TTTReborn.Rounds
 
         protected override void OnTimeUp()
         {
+            base.OnTimeUp();
+
             // TODO: Allow users to close the menu themselves using mouse cursor.
             TTTPlayer.ClientClosePostRoundMenu();
 
-            if (CheckMinimumPlayers())
-            {
-                Gamemode.Game.Instance.ChangeRound(new PreRound());
-            }
-
-            base.OnTimeUp();
+            Gamemode.Game.Instance.ChangeRound(new PreRound());
         }
 
         public override void OnPlayerSpawn(TTTPlayer player)
@@ -63,18 +60,6 @@ namespace TTTReborn.Rounds
                     }
                 }
             }
-        }
-
-        private bool CheckMinimumPlayers()
-        {
-            if (Client.All.Count < TTTReborn.Gamemode.Game.TTTMinPlayers)
-            {
-                TTTReborn.Gamemode.Game.Instance.ChangeRound(new WaitingRound());
-
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/code/rounds/PreRound.cs
+++ b/code/rounds/PreRound.cs
@@ -43,12 +43,9 @@ namespace TTTReborn.Rounds
 
         protected override void OnTimeUp()
         {
-            if (CheckMinimumPlayers())
-            {
-                TTTReborn.Gamemode.Game.Instance.ChangeRound(new InProgressRound());
-            }
-
             base.OnTimeUp();
+
+            TTTReborn.Gamemode.Game.Instance.ChangeRound(new InProgressRound());
         }
 
         private static async Task StartRespawnTimer(TTTPlayer player)
@@ -71,18 +68,6 @@ namespace TTTReborn.Rounds
             AddPlayer(player);
 
             base.OnPlayerSpawn(player);
-        }
-
-        private bool CheckMinimumPlayers()
-        {
-            if (Client.All.Count < TTTReborn.Gamemode.Game.TTTMinPlayers)
-            {
-                TTTReborn.Gamemode.Game.Instance.ChangeRound(new WaitingRound());
-
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/code/rounds/PreRound.cs
+++ b/code/rounds/PreRound.cs
@@ -43,7 +43,10 @@ namespace TTTReborn.Rounds
 
         protected override void OnTimeUp()
         {
-            TTTReborn.Gamemode.Game.Instance.ChangeRound(new InProgressRound());
+            if (CheckMinimumPlayers())
+            {
+                TTTReborn.Gamemode.Game.Instance.ChangeRound(new InProgressRound());
+            }
 
             base.OnTimeUp();
         }
@@ -68,6 +71,18 @@ namespace TTTReborn.Rounds
             AddPlayer(player);
 
             base.OnPlayerSpawn(player);
+        }
+
+        private bool CheckMinimumPlayers()
+        {
+            if (Client.All.Count < TTTReborn.Gamemode.Game.TTTMinPlayers)
+            {
+                TTTReborn.Gamemode.Game.Instance.ChangeRound(new WaitingRound());
+
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/code/rounds/WaitingRound.cs
+++ b/code/rounds/WaitingRound.cs
@@ -14,7 +14,10 @@ namespace TTTReborn.Rounds
         {
             if (Host.IsServer)
             {
-                CheckMinimumPlayers();
+                if (TTTReborn.Gamemode.Game.HasMinimumPlayers())
+                {
+                    TTTReborn.Gamemode.Game.Instance.ForceRoundChange(new PreRound());
+                }
             }
         }
 
@@ -46,14 +49,6 @@ namespace TTTReborn.Rounds
             if (player.IsValid() && TTTReborn.Gamemode.Game.Instance.Round is WaitingRound)
             {
                 player.Respawn();
-            }
-        }
-
-        private void CheckMinimumPlayers()
-        {
-            if (Client.All.Count >= TTTReborn.Gamemode.Game.TTTMinPlayers)
-            {
-                TTTReborn.Gamemode.Game.Instance.ChangeRound(new PreRound());
             }
         }
     }


### PR DESCRIPTION
Before this change, there never have been a jump back to the `WaitingRound` if too many player disconnected and the minimum amount of players wasn't reached.

I changed it into the following behavior (if there are too few players):
- `PreRound`: Run the countdown until it reaches the end, then do a check for enough players (So if a player connects and disconnects, the whole preparing isn't started from the beginning every time).
- `InProgressRound`: Check every second for enough players. If there aren't enough (and still no winning team), switch to `WaitingRound`
- `PostRound`: Same as `PreRound`