### PR TITLE
Bug: inspecting menu showing preround

### DIFF
--- a/code/player/TTTPlayer.cs
+++ b/code/player/TTTPlayer.cs
@@ -143,11 +143,7 @@ namespace TTTReborn.Player
 
             if (IsServer)
             {
-                if (Gamemode.Game.Instance.Round is Rounds.InProgressRound || Gamemode.Game.Instance.Round is Rounds.PostRound)
-                {
-                    TickAttemptInspectPlayerCorpse();
-                }
-
+                TickAttemptInspectPlayerCorpse();
                 TickPlayerFalling();
             }
 


### PR DESCRIPTION
I personally feel like we shouldn't be doing these types of checks, I'm pretty sure in regular TTT inspecting works always, the other issue is that we potentially run into bugs like these.

Bodies also delete pre-round, so inspecting these pre-round shouldn't be an issue.