### PR TITLE
Fix: Fixed weapon spawning when adding to the inventory failed

### DIFF
--- a/code/items/IBuyableItem.cs
+++ b/code/items/IBuyableItem.cs
@@ -10,9 +10,10 @@ namespace TTTReborn.Items
 
         void OnPurchase(TTTPlayer player)
         {
-            (player.Inventory as Inventory).Add(this);
-
-            Equip(player);
+            if ((player.Inventory as Inventory).TryAdd(this))
+            {
+                Equip(player);
+            }
         }
     }
 }

--- a/code/items/IItem.cs
+++ b/code/items/IItem.cs
@@ -1,3 +1,5 @@
+using Sandbox;
+
 using TTTReborn.Player;
 
 namespace TTTReborn.Items
@@ -6,12 +8,16 @@ namespace TTTReborn.Items
     {
         string Name { get; }
 
+        Entity Owner { get; }
+
         void Equip(TTTPlayer player);
 
-        void OnEquip(TTTPlayer player);
+        void OnEquip();
 
-        void Remove(TTTPlayer player);
+        void Remove();
 
-        void OnRemove(TTTPlayer player);
+        void OnRemove();
+
+        void Delete();
     }
 }

--- a/code/items/equipments/TTTEquipment.cs
+++ b/code/items/equipments/TTTEquipment.cs
@@ -29,20 +29,20 @@ namespace TTTReborn.Items
 
         public void Equip(TTTPlayer player)
         {
-            OnEquip(player);
+            OnEquip();
         }
 
-        public virtual void OnEquip(TTTPlayer player)
+        public virtual void OnEquip()
         {
 
         }
 
-        public void Remove(TTTPlayer player)
+        public void Remove()
         {
-            OnRemove(player);
+            OnRemove();
         }
 
-        public virtual void OnRemove(TTTPlayer player)
+        public virtual void OnRemove()
         {
 
         }

--- a/code/items/perks/TTTPerk.cs
+++ b/code/items/perks/TTTPerk.cs
@@ -17,6 +17,7 @@ namespace TTTReborn.Items
     public abstract class TTTPerk : IItem
     {
         public string Name { get; }
+        public Entity Owner { get; set; }
 
         protected TTTPerk()
         {
@@ -27,20 +28,27 @@ namespace TTTReborn.Items
 
         public void Equip(TTTPlayer player)
         {
-            OnEquip(player);
+            Owner = player;
+
+            OnEquip();
         }
 
-        public virtual void OnEquip(TTTPlayer player)
+        public virtual void OnEquip()
         {
 
         }
 
-        public void Remove(TTTPlayer player)
+        public void Remove()
         {
-            OnRemove(player);
+            OnRemove();
         }
 
-        public virtual void OnRemove(TTTPlayer player)
+        public virtual void OnRemove()
+        {
+
+        }
+
+        public void Delete()
         {
 
         }

--- a/code/items/weapons/TTTWeapon.cs
+++ b/code/items/weapons/TTTWeapon.cs
@@ -71,20 +71,20 @@ namespace TTTReborn.Items
 
         public void Equip(TTTPlayer player)
         {
-            OnEquip(player);
+            OnEquip();
         }
 
-        public virtual void OnEquip(TTTPlayer player)
+        public virtual void OnEquip()
         {
 
         }
 
-        public void Remove(TTTPlayer player)
+        public void Remove()
         {
-            OnRemove(player);
+            OnRemove();
         }
 
-        public virtual void OnRemove(TTTPlayer player)
+        public virtual void OnRemove()
         {
 
         }

--- a/code/player/Inventory.Perks.cs
+++ b/code/player/Inventory.Perks.cs
@@ -48,7 +48,8 @@ namespace TTTReborn.Player
 
             TTTPlayer player = Inventory.Owner as TTTPlayer;
 
-            perk.Remove(player);
+            perk.Remove();
+            perk.Delete();
 
             if (Host.IsServer)
             {
@@ -69,7 +70,8 @@ namespace TTTReborn.Player
 
             foreach (TTTPerk perk in PerkList)
             {
-                perk.Remove(player);
+                perk.Remove();
+                perk.Delete();
             }
 
             PerkList.Clear();

--- a/code/player/Inventory.cs
+++ b/code/player/Inventory.cs
@@ -21,6 +21,14 @@ namespace TTTReborn.Player
 
         public override void DeleteContents()
         {
+            foreach (Entity entity in List)
+            {
+                if (entity is IItem item)
+                {
+                    item.Remove();
+                }
+            }
+
             base.DeleteContents();
 
             TTTPlayer player = Owner as TTTPlayer;
@@ -57,11 +65,11 @@ namespace TTTReborn.Player
             return Perks.Give(perk);
         }
 
-        public bool Add(IItem item)
+        public bool Add(IItem item, bool makeActive = false)
         {
             if (item is Entity ent)
             {
-                return Add(ent);
+                return Add(ent, makeActive);
             }
             else if (item is TTTPerk perk)
             {
@@ -69,6 +77,24 @@ namespace TTTReborn.Player
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Tries to add an `TTTReborn.Items.IItem` to the inventory. If it fails, the given item is deleted
+        /// </summary>
+        /// <param name="item">`TTTReborn.Items.IItem` that will be added to the inventory or get removed on fail</param>
+        /// <param name="makeActive"></param>
+        /// <returns></returns>
+        public bool TryAdd(IItem item, bool makeActive = false)
+        {
+            if (!Add(item, makeActive))
+            {
+                item.Delete();
+
+                return false;
+            }
+
+            return true;
         }
 
         public bool IsCarryingType(Type t)

--- a/code/player/TTTPlayer.Commands.cs
+++ b/code/player/TTTPlayer.Commands.cs
@@ -69,6 +69,13 @@ namespace TTTReborn.Player
         [ServerCmd(Name = "requestitem")]
         public static void RequestItem(string itemName)
         {
+            TTTPlayer player = ConsoleSystem.Caller.Pawn as TTTPlayer;
+
+            if (!player.IsValid())
+            {
+                return;
+            }
+
             IBuyableItem item = null;
 
             Library.GetAll<IBuyableItem>().ToList().ForEach(t =>
@@ -82,9 +89,7 @@ namespace TTTReborn.Player
                 }
             });
 
-            TTTPlayer player = ConsoleSystem.Caller.Pawn as TTTPlayer;
-
-            if (item == null || !player.IsValid())
+            if (item == null)
             {
                 return;
             }

--- a/code/player/TTTPlayer.Shop.cs
+++ b/code/player/TTTPlayer.Shop.cs
@@ -36,16 +36,20 @@ namespace TTTReborn.Player
 
         public void RequestPurchase(IBuyableItem item)
         {
-            if (CanBuy(item) == BuyError.None)
-            {
-                Credits -= item.Price;
+            BuyError buyError = CanBuy(item);
 
-                item.OnPurchase(this);
+            if (buyError != BuyError.None)
+            {
+                Log.Warning($"{GetClientOwner().Name} tried to buy '{item.Name}'. (Error: {buyError})");
+
+                item.Delete();
 
                 return;
             }
 
-            Log.Warning($"{GetClientOwner().Name} tried to buy '{item.Name}'.");
+            Credits -= item.Price;
+
+            item.OnPurchase(this);
         }
     }
 }

--- a/code/rounds/InProgressRound.cs
+++ b/code/rounds/InProgressRound.cs
@@ -75,14 +75,22 @@ namespace TTTReborn.Rounds
                     Inventory inventory = player.Inventory as Inventory;
 
                     // TODO: Remove once we can spawn in carriable entities into the map, for now just give the guns to people.
-                    inventory.Add(new MagnetoStick(), true);
+                    inventory.TryAdd(new MagnetoStick(), true);
 
-                    inventory.Add(new Shotgun(), false);
-                    inventory.Ammo.Give(AmmoType.Buckshot, 16);
+                    if (inventory.TryAdd(new Shotgun(), false))
+                    {
+                        inventory.Ammo.Give(AmmoType.Buckshot, 8);
+                    }
 
-                    inventory.Add(new SMG(), false);
-                    inventory.Add(new Pistol(), false);
-                    inventory.Ammo.Give(AmmoType.Pistol, 120);
+                    if (inventory.TryAdd(new SMG(), false))
+                    {
+                        inventory.Ammo.Give(AmmoType.Buckshot, 8);
+                    }
+
+                    if (inventory.TryAdd(new Pistol(), false))
+                    {
+                        inventory.Ammo.Give(AmmoType.Pistol, 120);
+                    }
                 }
 
                 AssignRoles();

--- a/code/ui/QuickShop.cs
+++ b/code/ui/QuickShop.cs
@@ -81,14 +81,9 @@ namespace TTTReborn.UI
 
                 _wrapper = Add.Panel("wrapper");
 
-                foreach (Type type in Library.GetAll<IBuyableItem>())
+                foreach (Type type in Utils.GetTypes<IBuyableItem>())
                 {
-                    if (type.IsAbstract || type.ContainsGenericParameters)
-                    {
-                        continue;
-                    }
-
-                    IBuyableItem item = Library.Create<IBuyableItem>(type);
+                    IBuyableItem item = Utils.GetObjectByType<IBuyableItem>(type);
 
                     if (_selectedItem == null)
                     {
@@ -111,6 +106,13 @@ namespace TTTReborn.UI
             {
                 ItemPanel itemPanel = new ItemPanel(_wrapper);
                 itemPanel.SetItem(buyableItem);
+
+                // TODO if WeaponAttributes are fixed, this should get the Attribute's data instead of creating an item's object (weapon spawn bug)
+                // This is a workaround to avoid issues
+                if (buyableItem is TTTWeapon weapon)
+                {
+                    weapon.EnableDrawing = false;
+                }
 
                 itemPanel.AddEventListener("onclick", () =>
                 {


### PR DESCRIPTION
This does not fix the weapon spawning issue when the game hotloaded. It's caused by the shop item's creation and just can be fixed if we are able to use custom LibraryAttributes on weapons. Current workaround is to still spawn the weapons and just disable drawing (invisible weapons).

Thought about copying the data into a struct and then remove the created item again, but that would still spawn a weapon for a short time, so I just wanna wait for the fix sbox-sided.