### PR TITLE
Nameplate: Stop showing nameplate on incorrect camera

### DIFF
--- a/code/ui/generalhud/nameplate/Nameplate.cs
+++ b/code/ui/generalhud/nameplate/Nameplate.cs
@@ -87,6 +87,7 @@ namespace TTTReborn.UI
 
             if (Local.Pawn is not TTTPlayer player || player.Camera is ThirdPersonSpectateCamera)
             {
+                IsShowing = false;
                 return;
             }
 


### PR DESCRIPTION
Fixes https://github.com/TTTReborn/tttreborn/issues/147