### PR TITLE
Fix: Postround sync

### DIFF
--- a/code/player/PlayerCorpse.cs
+++ b/code/player/PlayerCorpse.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 
 using Sandbox;
 
-using TTTReborn.Items;
-
 namespace TTTReborn.Player
 {
     public partial class PlayerCorpse : ModelEntity

--- a/code/player/TTTPlayer.Confirmation.cs
+++ b/code/player/TTTPlayer.Confirmation.cs
@@ -70,8 +70,6 @@ namespace TTTReborn.Player
                                 playerCorpse.Player.CorpseCredits = credits;
                             }
 
-                            playerCorpse.Player.GetClientOwner()?.SetScore("alive", false);
-
                             RPCs.ClientConfirmPlayer(this, playerCorpse, playerCorpse.Player, playerCorpse.Player.Role.Name, playerCorpse.Player.Team.Name, playerCorpse.GetConfirmationData(), playerCorpse.KillerWeapon, playerCorpse.Perks);
                         }
                     }
@@ -82,7 +80,7 @@ namespace TTTReborn.Player
 
                         if (IsClient)
                         {
-                            InspectMenu.Instance.InspectCorpse(playerCorpse.Player, playerCorpse.GetConfirmationData(), playerCorpse.KillerWeapon, playerCorpse.Perks);
+                            InspectMenu.Instance.InspectCorpse(playerCorpse);
                         }
                     }
                 }

--- a/code/player/TTTPlayer.cs
+++ b/code/player/TTTPlayer.cs
@@ -129,7 +129,7 @@ namespace TTTReborn.Player
                 {
                     SyncMIA();
                 }
-                else if (Gamemode.Game.Instance.Round is Rounds.PostRound && PlayerCorpse != null)
+                else if (Gamemode.Game.Instance.Round is Rounds.PostRound && PlayerCorpse != null && !PlayerCorpse.IsIdentified)
                 {
                     PlayerCorpse.IsIdentified = true;
 

--- a/code/player/TTTPlayer.cs
+++ b/code/player/TTTPlayer.cs
@@ -81,8 +81,6 @@ namespace TTTReborn.Player
 
             SetRole(new NoneRole());
 
-            GetClientOwner().SetScore("alive", true);
-
             IsMissingInAction = false;
 
             using (Prediction.Off())
@@ -126,7 +124,17 @@ namespace TTTReborn.Player
             using (Prediction.Off())
             {
                 RPCs.ClientOnPlayerDied(this);
-                SyncMIA();
+
+                if (Gamemode.Game.Instance.Round is Rounds.InProgressRound)
+                {
+                    SyncMIA();
+                }
+                else if (Gamemode.Game.Instance.Round is Rounds.PostRound && PlayerCorpse != null)
+                {
+                    PlayerCorpse.IsIdentified = true;
+
+                    RPCs.ClientConfirmPlayer(null, PlayerCorpse, this, Role.Name, Team.Name, PlayerCorpse.GetConfirmationData(), PlayerCorpse.KillerWeapon, PlayerCorpse.Perks);
+                }
             }
         }
 

--- a/code/rounds/PostRound.cs
+++ b/code/rounds/PostRound.cs
@@ -54,10 +54,16 @@ namespace TTTReborn.Rounds
                 {
                     foreach (TTTPlayer player in Utils.GetPlayers())
                     {
-                        RPCs.ClientSetRole(player, player.Role.Name);
+                        if (player.PlayerCorpse != null && player.PlayerCorpse.IsValid() && player.LifeState == LifeState.Dead)
+                        {
+                            player.PlayerCorpse.IsIdentified = true;
 
-                        // TODO move this to a method called after OnKilled() and use LifeState instead of Health
-                        player.GetClientOwner()?.SetScore("alive", player.Health > 0);
+                            RPCs.ClientConfirmPlayer(null, player.PlayerCorpse, player, player.Role.Name, player.Team.Name, player.PlayerCorpse.GetConfirmationData(), player.PlayerCorpse.KillerWeapon, player.PlayerCorpse.Perks);
+                        }
+                        else
+                        {
+                            RPCs.ClientSetRole(player, player.Role.Name);
+                        }
                     }
                 }
             }

--- a/code/rounds/PostRound.cs
+++ b/code/rounds/PostRound.cs
@@ -54,7 +54,7 @@ namespace TTTReborn.Rounds
                 {
                     foreach (TTTPlayer player in Utils.GetPlayers())
                     {
-                        if (player.PlayerCorpse != null && player.PlayerCorpse.IsValid() && player.LifeState == LifeState.Dead)
+                        if (player.PlayerCorpse != null && player.PlayerCorpse.IsValid() && player.LifeState == LifeState.Dead && !player.PlayerCorpse.IsIdentified)
                         {
                             player.PlayerCorpse.IsIdentified = true;
 

--- a/code/ui/generalhud/inspectmenu/InspectMenu.cs
+++ b/code/ui/generalhud/inspectmenu/InspectMenu.cs
@@ -13,12 +13,19 @@ namespace TTTReborn.UI
     {
         public static InspectMenu Instance;
 
+        public PlayerCorpse PlayerCorpse;
+
         public bool IsShowing
         {
             get => _isShowing;
             set
             {
                 _isShowing = value;
+
+                if (!_isShowing)
+                {
+                    PlayerCorpse = null;
+                }
 
                 SetClass("hide", !_isShowing);
             }
@@ -40,20 +47,28 @@ namespace TTTReborn.UI
             _confirmationPanel = new ConfirmationPanel(this);
         }
 
-        public void InspectCorpse(TTTPlayer deadPlayer, ConfirmationData confirmationData, string killerWeapon = null, string[] perks = null)
+        public void InspectCorpse(PlayerCorpse playerCorpse)
         {
-            IsShowing = true;
+            if (playerCorpse == null)
+            {
+                return;
+            }
 
-            if (confirmationData.Identified)
+            IsShowing = true;
+            PlayerCorpse = playerCorpse;
+
+            if (playerCorpse.IsIdentified)
             {
                 _confirmationHintPanel.SetClass("hide", true);
 
-                _confirmationPanel.SetPlayer(deadPlayer);
-                _confirmationPanel.SetConfirmationData(confirmationData);
-                _confirmationPanel.SetKillerWeapon(killerWeapon);
-                _confirmationPanel.SetPerks(perks);
+                _confirmationPanel.SetPlayer(playerCorpse.Player);
+                _confirmationPanel.SetConfirmationData(playerCorpse.GetConfirmationData());
+                _confirmationPanel.SetKillerWeapon(playerCorpse.KillerWeapon);
+                _confirmationPanel.SetPerks(playerCorpse.Perks);
                 _confirmationPanel.SetClass("hide", false);
-                _confirmationPanel.Style.BorderColor = deadPlayer.Role.Color;
+
+                _confirmationPanel.Style.BorderColor = playerCorpse.Player.Role.Color;
+                _confirmationPanel.Style.Dirty();
             }
             else
             {

--- a/code/ui/generalhud/scoreboard/Scoreboard.cs
+++ b/code/ui/generalhud/scoreboard/Scoreboard.cs
@@ -59,11 +59,6 @@ namespace TTTReborn.UI
         [Event("tttreborn.player.spawned")]
         private void OnPlayerSpawned(TTTPlayer player)
         {
-            if (player != Local.Client.Pawn)
-            {
-                return;
-            }
-
             UpdatePlayer(player.GetClientOwner());
         }
 

--- a/code/ui/generalhud/scoreboard/ScoreboardEntry.cs
+++ b/code/ui/generalhud/scoreboard/ScoreboardEntry.cs
@@ -20,7 +20,6 @@ namespace TTTReborn.UI
         private readonly Label _ping;
 
         private Client _client;
-        private TTTRole _currentRole;
 
         public ScoreboardEntry()
         {
@@ -31,6 +30,8 @@ namespace TTTReborn.UI
             _karma = Add.Label("", "karma");
             _score = Add.Label("", "score");
             _ping = Add.Label("", "ping");
+
+            Initialize();
         }
 
         public virtual void UpdateFrom(PlayerScore.Entry entry)
@@ -41,6 +42,19 @@ namespace TTTReborn.UI
             _karma.Text = entry.Get<int>("karma", 0).ToString();
             _score.Text = entry.Get<int>("score", 0).ToString();
             _ping.Text = entry.Get<int>("ping", 0).ToString();
+
+            if (_client == null)
+            {
+                Initialize();
+            }
+
+            if (_client?.Pawn is not TTTPlayer player)
+            {
+                return;
+            }
+
+            _roleColorLabel.Style.BackgroundColor = player.Role is NoneRole ? player.Role.Color : player.Role.Color.WithAlpha(0.75f);
+            _roleColorLabel.Style.Dirty();
         }
 
         private void Initialize()
@@ -56,26 +70,6 @@ namespace TTTReborn.UI
             }
 
             SetClass("me", SteamId == Local.Client?.SteamId);
-        }
-
-        public override void Tick()
-        {
-            base.Tick();
-
-            if (_client == null)
-            {
-                Initialize();
-            }
-
-            if (_client?.Pawn is not TTTPlayer player || _currentRole == player.Role)
-            {
-                return;
-            }
-
-            _currentRole = player.Role;
-
-            _roleColorLabel.Style.BackgroundColor = player.Role is Roles.NoneRole ? player.Role.Color : player.Role.Color.WithAlpha(0.75f);
-            _roleColorLabel.Style.Dirty();
         }
     }
 }


### PR DESCRIPTION
- Fixed dead players do not refresh on round end
- Fixed dead players do not get confirmed on round end
- Fixed InspectMenu is getting overwritten with different PlayerCorpse data if looking at a PlayerCorpse when another PlayerCorpse is confirmed
- Fixed Scoreboard update issue
- Removed unused score "alive" state