### PR TITLE
Fix for #204 (Damage Overlay bugged)

### DIFF
--- a/code/ui/Hud.cs
+++ b/code/ui/Hud.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 using Sandbox;
 using Sandbox.UI;
 

--- a/code/ui/Hud.cs
+++ b/code/ui/Hud.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 using Sandbox;
 using Sandbox.UI;
 
@@ -33,34 +36,7 @@ namespace TTTReborn.UI
                 Local.Hud?.Delete();
 
                 Hud hud = new();
-
-                if (Local.Client.Pawn is TTTPlayer player && player.LifeState == LifeState.Alive)
-                {
-                    hud.AliveHudPanel.CreateHud();
-                }
             }
-        }
-
-        [Event("tttreborn.player.spawned")]
-        private void OnPlayerSpawned(TTTPlayer player)
-        {
-            if (player != Local.Client.Pawn)
-            {
-                return;
-            }
-
-            Current?.AliveHudPanel.CreateHud();
-        }
-
-        [Event("tttreborn.player.died")]
-        private void OnPlayerDied(TTTPlayer player)
-        {
-            if (player != Local.Client.Pawn)
-            {
-                return;
-            }
-
-            Current?.AliveHudPanel.DeleteHud();
         }
 
         public class GeneralHud : TTTPanel
@@ -88,18 +64,10 @@ namespace TTTReborn.UI
             public AliveHud(Panel parent)
             {
                 Parent = parent;
-            }
 
-            public void CreateHud()
-            {
-                Parent.AddChild<DamageIndicator>();
-                Parent.AddChild<QuickShop>();
                 Parent.AddChild<DrowningIndicator>();
-            }
-
-            public void DeleteHud()
-            {
-                DeleteChildren(true);
+                Parent.AddChild<QuickShop>();
+                Parent.AddChild<DamageIndicator>();
             }
         }
     }

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -36,8 +36,6 @@ namespace TTTReborn.UI
 
             _lastDamage = damage;
             _timeSinceLastDamage = 0f;
-            _additionalDamageIndicatorDuration += _currentRemainingDamageIndicatorDuration;
-            _currentRemainingDamageIndicatorDuration = 0f;
         }
 
         public override void Tick()
@@ -51,10 +49,10 @@ namespace TTTReborn.UI
 
             float remainingDamageIndicatorTime = _lastDamage / player.MaxHealth * 20;
 
-            if (_additionalDamageIndicatorDuration != 0f)
+            if(_currentRemainingDamageIndicatorDuration != 0)
             {
-                remainingDamageIndicatorTime += _additionalDamageIndicatorDuration;
-                _additionalDamageIndicatorDuration = 0f;
+                remainingDamageIndicatorTime += _currentRemainingDamageIndicatorDuration;
+                _currentRemainingDamageIndicatorDuration = 0f;
             }
 
             remainingDamageIndicatorTime = Math.Min(remainingDamageIndicatorTime, _maxDamageIndicatorDuration);

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -49,7 +49,7 @@ namespace TTTReborn.UI
 
             float remainingDamageIndicatorTime = _lastDamage / player.MaxHealth * 20;
 
-            if(_currentRemainingDamageIndicatorDuration != 0)
+            if(_currentRemainingDamageIndicatorDuration != 0f)
             {
                 remainingDamageIndicatorTime += _currentRemainingDamageIndicatorDuration;
                 _currentRemainingDamageIndicatorDuration = 0f;

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -15,7 +15,6 @@ namespace TTTReborn.UI
         private float _currentRemainingDamageIndicatorDuration = 0f;
         private TimeSince _timeSinceLastDamage = 0f;
         private float _lastDamage = 0f;
-        private float _additionalDamageIndicatorDuration = 0f;
 
         public DamageIndicator()
         {
@@ -49,7 +48,7 @@ namespace TTTReborn.UI
 
             float remainingDamageIndicatorTime = _lastDamage / player.MaxHealth * 20;
 
-            if(_currentRemainingDamageIndicatorDuration != 0f)
+            if (_currentRemainingDamageIndicatorDuration != 0f)
             {
                 remainingDamageIndicatorTime += _currentRemainingDamageIndicatorDuration;
                 _currentRemainingDamageIndicatorDuration = 0f;

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -49,7 +49,7 @@ namespace TTTReborn.UI
                 return;
             }
 
-            float remainingDamageIndicatorTime = _maxDamageIndicatorDuration * (_lastDamage / player.MaxHealth);
+            float remainingDamageIndicatorTime = _lastDamage / player.MaxHealth * 20;
 
             if (_additionalDamageIndicatorDuration != 0f)
             {
@@ -57,13 +57,14 @@ namespace TTTReborn.UI
                 _additionalDamageIndicatorDuration = 0f;
             }
 
+            remainingDamageIndicatorTime = Math.Min(remainingDamageIndicatorTime, _maxDamageIndicatorDuration);
+
             if (_lastDamage > 0f && _timeSinceLastDamage < remainingDamageIndicatorTime)
             {
                 _currentRemainingDamageIndicatorDuration = remainingDamageIndicatorTime - _timeSinceLastDamage;
 
                 Style.Display = DisplayMode.Flex;
                 Style.Opacity = Math.Clamp((_currentRemainingDamageIndicatorDuration / remainingDamageIndicatorTime) * (remainingDamageIndicatorTime / _maxDamageIndicatorDuration), 0f, 1f);
-                Style.Dirty();
             }
             else
             {
@@ -71,6 +72,7 @@ namespace TTTReborn.UI
 
                 Style.Display = DisplayMode.None;
             }
+            Style.Dirty();
         }
     }
 }

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -49,7 +49,7 @@ namespace TTTReborn.UI
                 return;
             }
 
-            float remainingDamageIndicatorTime = _maxDamageIndicatorDuration * (_lastDamage / player.MaxHealth);
+            float remainingDamageIndicatorTime = Math.Max(_lastDamage / player.MaxHealth, _maxDamageIndicatorDuration);
 
             if (_additionalDamageIndicatorDuration != 0f)
             {

--- a/code/ui/alivehud/damageindicator/DamageIndicator.cs
+++ b/code/ui/alivehud/damageindicator/DamageIndicator.cs
@@ -49,7 +49,7 @@ namespace TTTReborn.UI
                 return;
             }
 
-            float remainingDamageIndicatorTime = Math.Max(_lastDamage / player.MaxHealth, _maxDamageIndicatorDuration);
+            float remainingDamageIndicatorTime = _maxDamageIndicatorDuration * (_lastDamage / player.MaxHealth);
 
             if (_additionalDamageIndicatorDuration != 0f)
             {


### PR DESCRIPTION
Fixed issue where maximum duration
of indicator was multiplied instead of getting max value out of it.

(Example)
If player types kill in console he would receive 1000 damage which will cause overlay to stay for 100s.