### PR TITLE
Ignore s&box build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ config/*
 *.fgd
 globals.json
 
+# Sandbox generated
+.intermediate
+
 # User-specific files
 *.rsuser
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ config/*
 *.fgd
 globals.json
 
-# Sandbox generated
+# s&box generated
 .intermediate
 
 # User-specific files


### PR DESCRIPTION
This allows developers to directly clone this project into their s&box addons folder without having to worry about committing build files from the game.