### PR TITLE
Added a "NonSpawnable" Attribute

### DIFF
--- a/code/global/Utils.cs
+++ b/code/global/Utils.cs
@@ -142,6 +142,17 @@ namespace TTTReborn.Globals
         }
 
         /// <summary>
+        /// Loops through every type derived from the given type and collects non-abstract types that matches the given predicate.
+        /// </summary>
+        /// <param name="predicate">a filter function to limit the scope</param>
+        /// <returns>List of all available and matching types of the given type</returns>
+        public static List<Type> GetTypes<T>(Func<Type, bool> predicate)
+        {
+            return Library.GetAll<T>().Where(t => { return !t.IsAbstract && !t.ContainsGenericParameters; } )
+                .Where(predicate).ToList();
+        }
+
+        /// <summary>
         /// Get a derived `Type` of the given type by it's name (`Sandbox.LibraryAttribute`).
         /// </summary>
         /// <param name="name">The name of the `Sandbox.LibraryAttribute`</param>

--- a/code/items/NonSpawnableAttribute.cs
+++ b/code/items/NonSpawnableAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TTTReborn.Items
+{
+
+    /// <summary>
+    /// Prevents this Entity to be spawned from a TTTWeaponRandom
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class NonSpawnableAttribute : Attribute
+    {
+    }
+}

--- a/code/items/weapons/NewtonLauncher.cs
+++ b/code/items/weapons/NewtonLauncher.cs
@@ -1,7 +1,5 @@
 using System;
-
 using Hammer;
-
 using Sandbox;
 
 
@@ -9,6 +7,7 @@ namespace TTTReborn.Items
 {
     [Library("ttt_newton_launcher")]
     [EditorModel("weapons/rust_pistol/rust_pistol.vmdl")]
+    [NonSpawnable]
     partial class NewtonLauncher : TTTWeapon, IBuyableItem
     {
         public override string ViewModelPath => "weapons/rust_pistol/v_rust_pistol.vmdl";
@@ -20,7 +19,6 @@ namespace TTTReborn.Items
         public override float ReloadTime => 2.3f;
         public override float DeployTime => 0.4f;
         public override int BaseDamage => 3;
-
         public virtual int Price => 100;
 
         public const int NEWTON_FORCE_MIN = 300;

--- a/code/items/weapons/TTTWeapon.cs
+++ b/code/items/weapons/TTTWeapon.cs
@@ -1,8 +1,6 @@
 using System;
-
 using Sandbox;
 using Sandbox.ScreenShake;
-
 using TTTReborn.Player;
 
 namespace TTTReborn.Items
@@ -21,7 +19,7 @@ namespace TTTReborn.Items
     //     }
     // }
 
-    [Library("ttt_weapon")]
+    [Library("ttt_weapon"), Hammer.Skip]
     public abstract partial class TTTWeapon : BaseWeapon, ICarriableItem
     {
         public virtual SlotType SlotType => SlotType.Primary;

--- a/code/items/weapons/TTTWeaponRandom.cs
+++ b/code/items/weapons/TTTWeaponRandom.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-
 using Sandbox;
 
 namespace TTTReborn.Items
@@ -10,7 +9,7 @@ namespace TTTReborn.Items
     {
         public void Activate()
         {
-            List<Type> wepTypes = Globals.Utils.GetTypes<TTTWeapon>();
+            List<Type> wepTypes = Globals.Utils.GetTypes<TTTWeapon>(w => !w.IsDefined(typeof(NonSpawnableAttribute), true));
 
             if (wepTypes.Count > 0)
             {


### PR DESCRIPTION
This adds an Attribute that should be used to prevent a TTTWeapon descendant from being spawned by a TTTWeaponRandom.

(Also I added the `Hammer.Skip` Attribute to the abstract class `TTTWeapon`.)