### PR TITLE
Replaced "is null" Type Checking with "== null" (#192)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = false:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = false:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 

--- a/code/lang/Language.cs
+++ b/code/lang/Language.cs
@@ -54,7 +54,7 @@ namespace TTTReborn.Globalization
         {
             object translation = GetRawTranslation(key);
 
-            if (translation is not null)
+            if (translation != null)
             {
                 return translation.ToString();
             }
@@ -76,7 +76,7 @@ namespace TTTReborn.Globalization
         {
             string translation = GetTranslation(key);
 
-            return args is null ? translation : String.Format(translation, args);
+            return args == null ? translation : String.Format(translation, args);
         }
 
         public void AddTranslationString(string key, string translation)

--- a/code/lang/TTTLanguage.cs
+++ b/code/lang/TTTLanguage.cs
@@ -104,7 +104,7 @@ namespace TTTReborn.Player
         [ClientCmd("ttt_language")]
         public static void ChangeLanguage(string name = null)
         {
-            if (name is null)
+            if (name == null)
             {
                 Log.Info($"Your current language is set to '{TTTLanguage.ActiveLanguage.Data.Name}' ('{TTTLanguage.ActiveLanguage.Data.Code}').");
 
@@ -113,7 +113,7 @@ namespace TTTReborn.Player
 
             Language language = TTTLanguage.GetLanguageByCode(name);
 
-            if (language is null)
+            if (language == null)
             {
                 Log.Warning($"Language '{name}' does not exist. Please enter an ISO (tag) code (http://www.lingoes.net/en/translator/langcode.htm).");
 

--- a/code/settings/Settings.cs
+++ b/code/settings/Settings.cs
@@ -154,7 +154,7 @@ namespace TTTReborn.Settings
                 {
                     settings = GetSettings<T>(FileSystem.Data.ReadAllText(path + fileName + SETTINGS_FILE_EXTENSION));
 
-                    if (settings is null)
+                    if (settings == null)
                     {
                         settingsLoadingError = SettingsLoadingError.Empty;
                     }
@@ -178,7 +178,7 @@ namespace TTTReborn.Settings
                 settingsLoadingError = SettingsLoadingError.NotExist;
             }
 
-            if (settings is null)
+            if (settings == null)
             {
                 settingsLoadingError = SettingsLoadingError.Empty;
 
@@ -197,7 +197,7 @@ namespace TTTReborn.Settings
                 FileSystem.Data.CreateDirectory("settings");
             }
 
-            if (settings is null)
+            if (settings == null)
             {
                 return;
             }

--- a/code/ui/components/dropdown/Dropdown.cs
+++ b/code/ui/components/dropdown/Dropdown.cs
@@ -128,7 +128,7 @@ namespace Sandbox.UI.Construct
         {
             Dropdown dropdown = self.panel.AddChild<Dropdown>();
 
-            if (className is not null)
+            if (className != null)
             {
                 dropdown.AddClass(className);
             }

--- a/code/ui/components/modal/fileselection/FileSelection.cs
+++ b/code/ui/components/modal/fileselection/FileSelection.cs
@@ -176,7 +176,7 @@ namespace TTTReborn.UI
 
         public override void OnClickAgree()
         {
-            if (SelectedEntry is not null)
+            if (SelectedEntry != null)
             {
                 if (!FolderOnly && SelectedEntry.IsFolder)
                 {


### PR DESCRIPTION
Hey, wanted to get my feet wet with s&box and C# after some experience with GMod (TTT) Addons.

This should cover all `is null` checks currently in the Code as described in Issue #192. For reference i just checked against the following RegExp `/is\s+(?:not\s+)?null/`.

I think it would be a good idea to enforce this in the CI, but i don't know enough about dotnet-format if it could be enforced with that alone. And I didn't wanna tinker with the config without your input 😃