### PR TITLE
Null reference hand fix

### DIFF
--- a/code/items/equipments/Hands.cs
+++ b/code/items/equipments/Hands.cs
@@ -156,7 +156,7 @@ namespace TTTReborn.Items
             }
 
             // Only allow dynamic entities to be picked up.
-            if (tr.Body?.BodyType == PhysicsBodyType.Keyframed || tr.Body?.BodyType == PhysicsBodyType.Static)
+            if (tr.Body == null || tr.Body.BodyType == PhysicsBodyType.Keyframed || tr.Body.BodyType == PhysicsBodyType.Static)
             {
                 return;
             }

--- a/code/items/equipments/Hands.cs
+++ b/code/items/equipments/Hands.cs
@@ -156,7 +156,7 @@ namespace TTTReborn.Items
             }
 
             // Only allow dynamic entities to be picked up.
-            if (tr.Body.BodyType == PhysicsBodyType.Keyframed || tr.Body.BodyType == PhysicsBodyType.Static)
+            if (tr.Body?.BodyType == PhysicsBodyType.Keyframed || tr.Body?.BodyType == PhysicsBodyType.Static)
             {
                 return;
             }


### PR DESCRIPTION
Another null check needed, ran it through some testing, should be good now. `BodyType` will exist if `Body` does.