### PR TITLE
Fix: Use PlayerId instead of SteamId

### DIFF
--- a/code/events/TTTEvent.Player.cs
+++ b/code/events/TTTEvent.Player.cs
@@ -30,7 +30,7 @@ namespace TTTReborn.Events
 
             /// <summary>
             /// Occurs when a player disconnects.
-            /// <para>The <strong><see cref="ulong"/></strong> of the player's SteamId who disconnected.</para>
+            /// <para>The <strong><see cref="ulong"/></strong> of the player's playerId who disconnected.</para>
             /// <para>The <strong><see cref="Sandbox.NetworkDisconnectionReason"/></strong>.</para>
             /// </summary>
             public const string Disconnected = "tttreborn.player.disconnected";

--- a/code/events/TTTEvent.Player.cs
+++ b/code/events/TTTEvent.Player.cs
@@ -30,7 +30,7 @@ namespace TTTReborn.Events
 
             /// <summary>
             /// Occurs when a player disconnects.
-            /// <para>The <strong><see cref="ulong"/></strong> of the player's playerId who disconnected.</para>
+            /// <para>The <strong><see cref="ulong"/></strong> of the player's PlayerId who disconnected.</para>
             /// <para>The <strong><see cref="Sandbox.NetworkDisconnectionReason"/></strong>.</para>
             /// </summary>
             public const string Disconnected = "tttreborn.player.disconnected";

--- a/code/gamemode/Game.cs
+++ b/code/gamemode/Game.cs
@@ -138,9 +138,9 @@ namespace TTTReborn.Gamemode
 
             Round.OnPlayerLeave(client.Pawn as TTTPlayer);
 
-            Event.Run(TTTEvent.Player.Disconnected, client.SteamId, reason);
+            Event.Run(TTTEvent.Player.Disconnected, client.PlayerId, reason);
 
-            RPCs.ClientOnPlayerDisconnect(client.SteamId, reason);
+            RPCs.ClientOnPlayerDisconnect(client.PlayerId, reason);
 
             base.ClientDisconnect(client, reason);
         }
@@ -171,13 +171,13 @@ namespace TTTReborn.Gamemode
         /// Someone is speaking via voice chat. This might be someone in your game,
         /// or in your party, or in your lobby.
         /// </summary>
-        public override void OnVoicePlayed(ulong steamId, float level)
+        public override void OnVoicePlayed(long playerId, float level)
         {
             Client client = null;
 
             foreach (Client loopClient in Client.All)
             {
-                if (loopClient.SteamId == steamId)
+                if (loopClient.PlayerId == playerId)
                 {
                     client = loopClient;
 

--- a/code/gamemode/Karma.cs
+++ b/code/gamemode/Karma.cs
@@ -53,25 +53,25 @@ namespace TTTReborn.Gamemode
             //int updatedDamage = 0;
 
             // TODO: Once network dictionaries are supported, implement.
-            // DamageRecords.TryGetValue((attacker.SteamId, victim.SteamId), out updatedDamage);
+            // DamageRecords.TryGetValue((attacker.PlayerId, victim.PlayerId), out updatedDamage);
             //
             // updatedDamage += damage;
             // updatedDamage = Math.Min(updatedDamage, 100);
             //
-            // DamageRecords[(attacker.SteamId, victim.SteamId)] = updatedDamage;
+            // DamageRecords[(attacker.PlayerId, victim.PlayerId)] = updatedDamage;
         }
 
         public void UpdatePlayerKarma(TTTPlayer player, int delta)
         {
-            UpdateSteamIdKarma(player.Client.SteamId, delta);
+            UpdatePlayerIdKarma(player.Client.PlayerId, delta);
         }
 
-        public void UpdateSteamIdKarma(ulong steamId, int delta)
+        public void UpdatePlayerIdKarma(long playerId, int delta)
         {
             int updatedKarma = 0;
 
             // TODO: Once network dictionaries are supported, implement.
-            // KarmaRecords.TryGetValue(steamId, out updatedKarma);
+            // KarmaRecords.TryGetValue(playerId, out updatedKarma);
 
             updatedKarma += delta;
 
@@ -80,7 +80,7 @@ namespace TTTReborn.Gamemode
             updatedKarma = updatedKarma < TTTKarmaMin ? TTTKarmaMin : updatedKarma;
 
             // TODO: Once network dictionaries are supported, implement.
-            // KarmaRecords[player.SteamId] = updatedKarma;
+            // KarmaRecords[player.playerId] = updatedKarma;
         }
 
         public void ResolveKarma()
@@ -91,7 +91,7 @@ namespace TTTReborn.Gamemode
                 // Update karma records based on the damage done this round
                 // foreach (var record in DamageRecords)
                 // {
-                //  UpdateSteamIdKarma(record.Key.Item1, record.Value);
+                //  UpdatePlayerIdKarma(record.Key.Item1, record.Value);
                 // }
             }
 
@@ -103,7 +103,7 @@ namespace TTTReborn.Gamemode
         public bool IsBanned(TTTPlayer player)
         {
             // TODO: Once network dictionaries are supported, implement. Return false meanwhile...
-            // return (KarmaRecords[player.SteamId] < TTTKarmaMin && TTTKarmaBan);
+            // return (KarmaRecords[player.PlayerId] < TTTKarmaMin && TTTKarmaBan);
             return false;
         }
     }

--- a/code/global/RPCs.cs
+++ b/code/global/RPCs.cs
@@ -29,9 +29,9 @@ namespace TTTReborn.Globals
         }
 
         [ClientRpc]
-        public static void ClientOnPlayerDisconnect(ulong steamId, NetworkDisconnectionReason reason)
+        public static void ClientOnPlayerDisconnect(long playerId, NetworkDisconnectionReason reason)
         {
-            Event.Run(TTTEvent.Player.Disconnected, steamId, reason);
+            Event.Run(TTTEvent.Player.Disconnected, playerId, reason);
         }
 
         [ClientRpc]

--- a/code/items/perks/radar/Radar.cs
+++ b/code/items/perks/radar/Radar.cs
@@ -55,7 +55,7 @@ namespace TTTReborn.Items
 
                 foreach (TTTPlayer player in Globals.Utils.GetAlivePlayers())
                 {
-                    if (player.Client.UserId == owner.Client.UserId)
+                    if (player.Client.PlayerId == owner.Client.PlayerId)
                     {
                         continue;
                     }

--- a/code/player/TTTPlayer.AFK.cs
+++ b/code/player/TTTPlayer.AFK.cs
@@ -44,13 +44,13 @@ namespace TTTReborn.Player
 
                 if (shouldKick)
                 {
-                    Log.Warning($"Steam ID: {Client.SteamId}, Name: {Client.Name} was kicked from the server for being AFK.");
+                    Log.Warning($"Player ID: {Client.PlayerId}, Name: {Client.Name} was kicked from the server for being AFK.");
 
                     Client.Kick();
                 }
                 else
                 {
-                    Log.Warning($"Steam ID: {Client.SteamId}, Name: {Client.Name} was moved to spectating for being AFK.");
+                    Log.Warning($"Player ID: {Client.PlayerId}, Name: {Client.Name} was moved to spectating for being AFK.");
 
                     ToggleForcedSpectator();
                 }

--- a/code/ui/generalhud/chat/ChatBox.cs
+++ b/code/ui/generalhud/chat/ChatBox.cs
@@ -262,11 +262,11 @@ namespace TTTReborn.UI
 
             if (Gamemode.Game.Instance?.Round is Rounds.InProgressRound && lifeState == LifeState.Dead)
             {
-                AddChatEntry(To.Multiple(Utils.GetClients((pl) => pl.LifeState == LifeState.Dead)), ConsoleSystem.Caller.Name, message, Channel.Spectator, $"avatar:{ConsoleSystem.Caller.SteamId}");
+                AddChatEntry(To.Multiple(Utils.GetClients((pl) => pl.LifeState == LifeState.Dead)), ConsoleSystem.Caller.Name, message, Channel.Spectator, $"avatar:{ConsoleSystem.Caller.PlayerId}");
             }
             else
             {
-                AddChatEntry(To.Everyone, ConsoleSystem.Caller.Name, message, Channel.Player, $"avatar:{ConsoleSystem.Caller.SteamId}");
+                AddChatEntry(To.Everyone, ConsoleSystem.Caller.Name, message, Channel.Player, $"avatar:{ConsoleSystem.Caller.PlayerId}");
             }
         }
 
@@ -287,7 +287,7 @@ namespace TTTReborn.UI
 
             player.Team.Members.ForEach(member => clients.Add(member.Client));
 
-            AddChatEntry(To.Multiple(clients), ConsoleSystem.Caller.Name, message, Channel.Team, $"avatar:{ConsoleSystem.Caller.SteamId}", player.Team.Name);
+            AddChatEntry(To.Multiple(clients), ConsoleSystem.Caller.Name, message, Channel.Team, $"avatar:{ConsoleSystem.Caller.PlayerId}", player.Team.Name);
         }
     }
 }

--- a/code/ui/generalhud/inspectmenu/InspectMenu.cs
+++ b/code/ui/generalhud/inspectmenu/InspectMenu.cs
@@ -133,7 +133,7 @@ namespace TTTReborn.UI
 
             _playerCorpse = playerCorpse;
 
-            _avatarImage.SetTexture($"avatar:{_playerCorpse.Player?.Client.SteamId}");
+            _avatarImage.SetTexture($"avatar:{_playerCorpse.Player?.Client.PlayerId}");
 
             _playerLabel.Text = _playerCorpse.Player?.Client.Name;
 

--- a/code/ui/generalhud/scoreboard/Scoreboard.cs
+++ b/code/ui/generalhud/scoreboard/Scoreboard.cs
@@ -21,9 +21,9 @@ namespace TTTReborn.UI
 
         public static Scoreboard Instance;
 
-        private readonly Dictionary<ulong, ScoreboardEntry> _entries = new();
+        private readonly Dictionary<long, ScoreboardEntry> _entries = new();
         private readonly Dictionary<string, ScoreboardGroup> _scoreboardGroups = new();
-        private readonly Dictionary<ulong, bool> _forcedSpecList = new();
+        private readonly Dictionary<long, bool> _forcedSpecList = new();
 
         private readonly Panel _backgroundPanel;
         private readonly Panel _scoreboardContainer;
@@ -101,9 +101,9 @@ namespace TTTReborn.UI
         }
 
         [Event(TTTEvent.Player.Disconnected)]
-        private void OnPlayerDisconnected(ulong steamId, NetworkDisconnectionReason reason)
+        private void OnPlayerDisconnected(long playerId, NetworkDisconnectionReason reason)
         {
-            RemoveClient(steamId);
+            RemoveClient(playerId);
             UpdateScoreboardGroups();
         }
 
@@ -116,7 +116,7 @@ namespace TTTReborn.UI
                 return;
             }
 
-            if (_entries.TryGetValue(client.SteamId, out ScoreboardEntry panel))
+            if (_entries.TryGetValue(client.PlayerId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -126,7 +126,7 @@ namespace TTTReborn.UI
 
             scoreboardGroup.GroupMembers++;
 
-            _entries.Add(client.SteamId, scoreboardEntry);
+            _entries.Add(client.PlayerId, scoreboardEntry);
 
             scoreboardGroup.UpdateLabel();
             _scoreboardHeader.UpdateServerInfo();
@@ -134,7 +134,7 @@ namespace TTTReborn.UI
 
         public void UpdateClient(Client client)
         {
-            if (!_entries.TryGetValue(client.SteamId, out ScoreboardEntry panel))
+            if (!_entries.TryGetValue(client.PlayerId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -144,7 +144,7 @@ namespace TTTReborn.UI
             if (scoreboardGroup.GroupTitle != panel.ScoreboardGroupName)
             {
                 // instead of remove and add, move the panel into the right parent
-                RemoveClient(client.SteamId);
+                RemoveClient(client.PlayerId);
                 AddClient(client);
             }
             else
@@ -163,9 +163,9 @@ namespace TTTReborn.UI
             }
         }
 
-        public void RemoveClient(ulong steamId)
+        public void RemoveClient(long playerId)
         {
-            if (!_entries.TryGetValue(steamId, out ScoreboardEntry panel))
+            if (!_entries.TryGetValue(playerId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -180,7 +180,7 @@ namespace TTTReborn.UI
             scoreboardGroup.UpdateLabel();
 
             panel.Delete();
-            _entries.Remove(steamId);
+            _entries.Remove(playerId);
         }
 
         public override void Tick()
@@ -192,13 +192,13 @@ namespace TTTReborn.UI
             {
                 bool newIsForcedSpectator = client.GetValue<bool>("forcedspectator");
 
-                if (!_forcedSpecList.TryGetValue(client.SteamId, out bool isForcedSpectator))
+                if (!_forcedSpecList.TryGetValue(client.PlayerId, out bool isForcedSpectator))
                 {
-                    _forcedSpecList.Add(client.SteamId, newIsForcedSpectator);
+                    _forcedSpecList.Add(client.PlayerId, newIsForcedSpectator);
                 }
                 else if (isForcedSpectator != newIsForcedSpectator)
                 {
-                    _forcedSpecList[client.SteamId] = newIsForcedSpectator;
+                    _forcedSpecList[client.PlayerId] = newIsForcedSpectator;
 
                     UpdateClient(client);
                 }
@@ -232,7 +232,7 @@ namespace TTTReborn.UI
             {
                 group = DefaultScoreboardGroup.Spectator.ToString();
             }
-            else if (client.SteamId != 0 && client.Pawn is TTTPlayer player)
+            else if (client.PlayerId != 0 && client.Pawn is TTTPlayer player)
             {
                 if (player.IsConfirmed)
                 {

--- a/code/ui/generalhud/scoreboard/ScoreboardEntry.cs
+++ b/code/ui/generalhud/scoreboard/ScoreboardEntry.cs
@@ -60,7 +60,7 @@ namespace TTTReborn.UI
                 Style.BackgroundColor = null;
             }
 
-            _playerAvatar.SetTexture($"avatar:{Client.SteamId}");
+            _playerAvatar.SetTexture($"avatar:{Client.PlayerId}");
         }
 
         public override void Tick()

--- a/code/ui/generalhud/voicechat/VoiceChatEntry.cs
+++ b/code/ui/generalhud/voicechat/VoiceChatEntry.cs
@@ -30,10 +30,10 @@ namespace TTTReborn.UI
             Parent = parent;
 
             Client = client;
-            Friend = new(client.SteamId);
+            Friend = new(client.PlayerId);
 
             Avatar = Add.Image("", "avatar");
-            Avatar.SetTexture($"avatar:{client.SteamId}");
+            Avatar.SetTexture($"avatar:{client.PlayerId}");
             Avatar.AddClass("circular");
 
             Name = Add.Label(Friend.Name, "name");


### PR DESCRIPTION
`SteamId` is now marked as obsolete from FacePunch