### PR TITLE
Fea: Show buy error items, scroll quickshop, fix quick shop description

### DIFF
--- a/code/ui/alivehud/quickshop/QuickShop.cs
+++ b/code/ui/alivehud/quickshop/QuickShop.cs
@@ -88,8 +88,6 @@ namespace TTTReborn.UI
 
             foreach (ShopItemData itemData in shop.Items)
             {
-                _selectedItemData ??= itemData;
-
                 AddItem(itemData);
             }
         }
@@ -123,6 +121,9 @@ namespace TTTReborn.UI
                 if (_selectedItemData?.IsBuyable(Local.Pawn as TTTPlayer) ?? false)
                 {
                     TTTPlayer.RequestItem(item.ItemData?.Name);
+
+                    // The item was purchased, let's deselect it from the UI.
+                    _selectedItemData = null;
                 }
 
                 Update();

--- a/code/ui/alivehud/quickshop/QuickShop.scss
+++ b/code/ui/alivehud/quickshop/QuickShop.scss
@@ -29,12 +29,11 @@ QuickShop {
         }
 
         .item-panel {
-            max-width: 50%;
-            display: flex;
             flex-wrap: wrap;
-            align-items: center;
-            justify-content: center;
-            margin: 25px;
+            max-width: 680px;
+            overflow: scroll;
+            justify-content: start;
+            max-height: 700px;
         }
 
         .item-description-label {
@@ -59,7 +58,7 @@ QuickShopItem {
     flex-direction: column;
     width: 90px;
     height: 90px;
-    margin: 25px;
+    margin: 40px;
     align-items: center;
     justify-content: center;
     padding: 8px;
@@ -75,6 +74,12 @@ QuickShopItem {
 
     &:active {
         transform: scale(1);
+    }
+
+    &.buy-error {
+        opacity: 0.35;
+        transform: scale(1);
+        cursor: none;
     }
 
     .item-icon {

--- a/code/ui/alivehud/quickshop/QuickShop.scss
+++ b/code/ui/alivehud/quickshop/QuickShop.scss
@@ -76,7 +76,7 @@ QuickShopItem {
         transform: scale(1);
     }
 
-    &.buy-error {
+    &.cannot-purchase {
         opacity: 0.35;
         transform: scale(1);
         cursor: none;

--- a/code/ui/alivehud/quickshop/QuickShop.scss
+++ b/code/ui/alivehud/quickshop/QuickShop.scss
@@ -76,12 +76,6 @@ QuickShopItem {
         transform: scale(1);
     }
 
-    &.cannot-purchase {
-        opacity: 0.35;
-        transform: scale(1);
-        cursor: none;
-    }
-
     .item-icon {
         background-repeat: no-repeat;
         background-size: contain;

--- a/code/ui/alivehud/quickshop/QuickShopItem.cs
+++ b/code/ui/alivehud/quickshop/QuickShopItem.cs
@@ -45,8 +45,15 @@ namespace TTTReborn.UI
 
         public void Update()
         {
-            IsDisabled = (Local.Pawn as TTTPlayer).CanBuy(ItemData) != BuyError.None;
-            SetClass("buy-error", IsDisabled);
+            BuyError buyError = (Local.Pawn as TTTPlayer).CanBuy(ItemData);
+
+            // Let's not show any items that the player could not access in the first place, or
+            // items that have had their limit reached.
+            SetClass("disabled", buyError == BuyError.NoAccess || buyError == BuyError.LimitReached);
+
+            // Decrease the opacity to show that the item cannot be purchased
+            // ex. lack of credits
+            SetClass("cannot-purchase", buyError != BuyError.None);
         }
     }
 }

--- a/code/ui/alivehud/quickshop/QuickShopItem.cs
+++ b/code/ui/alivehud/quickshop/QuickShopItem.cs
@@ -46,7 +46,7 @@ namespace TTTReborn.UI
         public void Update()
         {
             IsDisabled = (Local.Pawn as TTTPlayer).CanBuy(ItemData) != BuyError.None;
-            Enabled = !IsDisabled;
+            SetClass("buy-error", IsDisabled);
         }
     }
 }

--- a/code/ui/alivehud/quickshop/QuickShopItem.cs
+++ b/code/ui/alivehud/quickshop/QuickShopItem.cs
@@ -45,15 +45,8 @@ namespace TTTReborn.UI
 
         public void Update()
         {
-            BuyError buyError = (Local.Pawn as TTTPlayer).CanBuy(ItemData);
-
-            // Let's not show any items that the player could not access in the first place, or
-            // items that have had their limit reached.
-            SetClass("disabled", buyError == BuyError.NoAccess || buyError == BuyError.LimitReached);
-
-            // Decrease the opacity to show that the item cannot be purchased
-            // ex. lack of credits
-            SetClass("cannot-purchase", buyError != BuyError.None);
+            IsDisabled = (Local.Pawn as TTTPlayer).CanBuy(ItemData) != BuyError.None;
+            Enabled = !IsDisabled;
         }
     }
 }


### PR DESCRIPTION

1. Fixed showcasing a description of an item when nothing was selected
2. Allow the quickshop to scroll if there is a huge amount of items
